### PR TITLE
fix(useNTState): Publish topic when created with useNTState

### DIFF
--- a/src/lib/useNTState.ts
+++ b/src/lib/useNTState.ts
@@ -30,9 +30,7 @@ const useNTState = <T extends NTTopicTypes>(
             const clientTopic = client.createTopic(key, ntType, defaultValue);
             setTopic(clientTopic);
             const subscriptionUID = clientTopic.subscribe(listener);
-            clientTopic.publish().then(() => {
-                console.log("Published topic:", key);
-            });
+            clientTopic.publish();
 
             return () => {
                 if (subscriptionUID && clientTopic) {

--- a/src/lib/useNTState.ts
+++ b/src/lib/useNTState.ts
@@ -30,6 +30,9 @@ const useNTState = <T extends NTTopicTypes>(
             const clientTopic = client.createTopic(key, ntType, defaultValue);
             setTopic(clientTopic);
             const subscriptionUID = clientTopic.subscribe(listener);
+            clientTopic.publish().then(() => {
+                console.log("Published topic:", key);
+            });
 
             return () => {
                 if (subscriptionUID && clientTopic) {


### PR DESCRIPTION
Previously, topics wouldn't be published when used with useNTState. Now this will happen by default, since useNTValue supports readonly values.